### PR TITLE
Add epsilon value before log in spec2cep

### DIFF
--- a/src/rasta.jl
+++ b/src/rasta.jl
@@ -224,6 +224,7 @@ function spec2cep{T<:AbstractFloat}(spec::Array{T}, ncep::Int=13, dcttype::Int=2
         end
         dctm[:, [1, nr]] /= 2
     end
+    spec = map(x -> x == 0 ? eps(x) : x, spec)
     return dctm * log.(spec)
 end
 


### PR DESCRIPTION
When the waveform is all zeros, NaNs appear.

```julia
using MFCC
println(mfcc(zeros(1000), 16000)[1])
# [-Inf NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN; ... ]
```

This is due in part to the log functions that are performed in the process of calculating the MFCCs, where if there are zeros, we end up with log(0). Adding an epsilon value to the 0s before taking the log fixed the issue. 

```julia
using MFCC
println(mfcc(zeros(1000), 16000)[1])
# [-4708.25 -7.29149e-14 4.66009e-13 -1.89956e-12 2.17192e-12 -1.39894e-12 -2.38229e-12 -2.9143e-12 6.25616e-13 -6.56793e-13 1.79075e-11 5.79803e-12 1.21636e-11; ... ]
```