### PR TITLE
Add compat bounds for HDF5 requirement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 WAV = "8149f6b0-98f6-5db9-b78f-408fbbb8ef88"
 
 [compat]
+HDF5 = "< 0.14.0"
 julia = "≥ 0.7.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 WAV = "8149f6b0-98f6-5db9-b78f-408fbbb8ef88"
 
 [compat]
-HDF5 = "< 0.14.0"
+HDF5 = "< 0.15.0"
 julia = "≥ 0.7.0"
 
 [extras]


### PR DESCRIPTION
This PR adds a compat bound for the HDF5 requirement to be any version older than the v0.15 releases. There were two small changes in v0.14 and up for HDF5 that broke some of the functionality in the io.jl file. Specifically:

* The `HDF5File` object is replaced with `HDF5.File`
* The `names` function is incompatible with `HDF5.File` and `keys` should be used instead

In v0.14, the old code used in io.jl throws a deprecation warning, though it errors in v0.15.

The update to the io.jl code is trivial to be compatible with the changes in newer releases of HDF5. However, older versions of Julia (like those used in the CI testing) are not compatible with the newer versions of HDF5. I'm not sure what balance is desired here, so I opted for allowing up to and including the newest version of HDF5 that would still allow the package to work on older versions of Julia.